### PR TITLE
Add copyright and license preamble to the .github/workflows files

### DIFF
--- a/.github/workflows/deployJSON.py
+++ b/.github/workflows/deployJSON.py
@@ -1,3 +1,26 @@
+#
+# deployJSON.py
+#
+# Copyright (C) 2021, SpaceLab.
+#
+# This file is part of OBDH 2.0.
+#
+# OBDH 2.0 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OBDH 2.0 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OBDH 2.0. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+
 import sys
 import os
 import json
@@ -22,10 +45,13 @@ else:
     }
 
     # Naming convention:
-    #   test files end with '_test.c'
-    #   and executables are '<target>_unit_test
-    #   makefile with options 'make <target>' for each test file
-    #   otherwise this script will have to be edited for each project
+    #   - test files should end with '_test.c';
+    #   - and executables should be named '<target>_unit_test
+    #   - makefile commands should be 'make <target>' for each test file
+    #
+    # This script should work for all folders that follow these guidelines
+    # otherwise this script will have to be edited to function properly
+
     for file in file_dir:
         if file.endswith('_test.c'):
             file_name = file.replace('.c', '')

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -1,3 +1,26 @@
+#
+# test-workflow.yml
+#
+# Copyright (C) 2021, SpaceLab.
+#
+# This file is part of OBDH 2.0.
+#
+# OBDH 2.0 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OBDH 2.0 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OBDH 2.0. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+
 name: Test Workflow
 
 on:
@@ -5,11 +28,18 @@ on:
     branches: [ dev_firmware ]
   pull_request:
     branches: [ master, dev, dev_firmware]
-  workflow_dispatch:  # allows manual execution
+
+  # 'workflow_dispatch' allows manual execution
+  # of this workflow under the repository's 'Actions' tab
+  workflow_dispatch:
 
 jobs:
 
   # Generates Matrix
+  # This job executes the 'deployJSON.py' script
+  # which compiles a list of all files ending in '_test.c'
+  # in a given directory and includes them in a .json file
+  # along with the path to the executable file.
   generate-matrix:
     name:
 
@@ -19,20 +49,24 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks-out the repository under $GITHUB_WORKSPACE, so the job can navigate it
       - uses: actions/checkout@v2
-      # Generates JSON file with test program
+
       - name: Create JSON file
         run: python3 .github/workflows/deployJSON.py --source firmware/tests/devices/
-      # Echo the JSON file
+
       - name: Resulting JSON file for matrix generation
         run: echo "$(cat .github/workflows/test-list.json)"
+
       # Set the matrix output from the JSON (manipulated to remove spaces and replace \n -> %0A, " -> \")
       - id: set-matrix
         name: Set matrix output from the JSON file
         run: echo "::set-output name=matrix::$( echo "$(cat .github/workflows/test-list.json)" | sed ':a;N;$!ba;s/\n/%0A/g' )"
 
-  # Job for executing all test files
+  # This job reads the matrix containing the paths
+  # created by the previous job and runs each program
+  # individually, i.e. spawning one job for every
+  # test file included in the matrix.
   run-tests:
     name: run-tests
     needs: generate-matrix
@@ -54,12 +88,15 @@ jobs:
       # Install required libs
       - name: Install CMocka
         run: sudo apt-get install libcmocka0 libcmocka-dev
+
       - name: Signal make target
         run: echo "Generating make file for $MAKE_TARGET"
+
       - name: Generate Test File
-        # '-lcmocka' must be the last compilation flag
         run: cd firmware/tests/devices && make $MAKE_TARGET
+
       - name: Signal running test
         run: echo "Running $TEST_FILE"
+
       - name: Run test
         run: $TEST_PATH


### PR DESCRIPTION
As stated in the project's [contributing guidelines](https://github.com/spacelab-ufsc/spacelab/blob/master/CONTRIBUTING.md), this PR adds a copyright and license preamble to both files in .github/workflows, as well as adding/tweaking comments to make the code clearer and easier to understand.