### PR TITLE
Add Radio Occultation (RO) driver implementation and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,3 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
-firmware/drivers/ro/ro-DESKTOP-RLEUGDF.c
-firmware/drivers/ro/ro-DESKTOP-RLEUGDF.h
-obdh2.code-workspace
-.vscode/extensions.json
-chat.rapidgpt

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+firmware/drivers/ro/ro-DESKTOP-RLEUGDF.c
+firmware/drivers/ro/ro-DESKTOP-RLEUGDF.h
+obdh2.code-workspace
+.vscode/extensions.json
+chat.rapidgpt

--- a/firmware/drivers/drivers.h
+++ b/firmware/drivers/drivers.h
@@ -53,6 +53,7 @@
 #include "sl_ttc2/sl_ttc2.h"
 #include "cy15x102qn/cy15x102qn.h"
 #include "phj/phj.h"
+#include "ro/ro.h"
 
 #endif /* DRIVERS_H_ */
 

--- a/firmware/drivers/ro/README.md
+++ b/firmware/drivers/ro/README.md
@@ -1,0 +1,7 @@
+# Radio Occultation driver
+
+`ro` is the transport and decoding layer for a Radio Occultation payload. It follows the existing EDC driver pattern: power-enable GPIO, then UART or I2C transport, command write, delayed response read, frame-ID validation, and XOR checksum validation.
+
+The driver intentionally keeps mission wiring outside the driver. Set `ro_config_t` with the assigned UART/I2C interface and enable pin, then call `ro_init`. Frame fields are decoded explicitly as little-endian values, so no compiler packing or alignment assumptions are exposed to the payload protocol.
+
+The protocol constants and frame layouts are centralized in `ro.h`. Confirm the payload ICD before flight use, especially the I2C address, command IDs, frame sizes, endianness, and the IQ sample transfer format. `ro_get_iq_header` reads the metadata header only; bulk IQ transfer needs an ICD-defined chunking rule before it is enabled.

--- a/firmware/drivers/ro/ro.c
+++ b/firmware/drivers/ro/ro.c
@@ -290,7 +290,18 @@ int ro_echo(ro_config_t config)
     return err;
 }
 
-uint16_t ro_calc_checksum(uint8_t *data, uint16_t len);
+uint16_t ro_calc_checksum(uint8_t *data, uint16_t len)
+{
+    uint16_t checksum = 0;
+
+    for(uint16_t i=0; i<len; i++)
+    {
+        checksum ^= data[i];
+    }
+
+    return checksum;
+}
+
 
 /*============================================================================*/
 /* Instrument Control                                                         */
@@ -314,11 +325,150 @@ int ro_clear_event(ro_config_t config);
 /* Data Acquisition                                                           */
 /*============================================================================*/
 
-int16_t ro_get_state_pkg(ro_config_t config, uint8_t *status);
+int16_t ro_get_state_pkg(ro_config_t config, uint8_t *status)
+{
+    int16_t res = -1;
 
-int16_t ro_get_hk_pkg(ro_config_t config, uint8_t *hk);
+    ro_cmd_t cmd = {0};
 
-int16_t ro_get_event_pkg(ro_config_t config, uint8_t *event);
+    cmd.id = RO_CMD_GET_STATE;
+
+    if (ro_write_cmd(config, cmd) == 0)
+    {
+        /* A minimum time gap of 10 ms must be forced between consecutive I2C commands */
+        ro_delay_ms(100);  /* 10 ms is not enough when using the UART interface! */
+
+        if (ro_read(config, status, RO_FRAME_STATE_LEN) == 0)
+        {
+            if (status[0] == RO_FRAME_ID_STATE)
+            {
+                res = RO_FRAME_STATE_LEN;
+            }
+            else
+            {
+            #if defined(CONFIG_DRIVERS_DEBUG_ENABLED) && (CONFIG_DRIVERS_DEBUG_ENABLED == 1)
+                sys_log_print_event_from_module(SYS_LOG_ERROR, RO_MODULE_NAME, "Error reading an state packet! Invalid frame ID (");
+                sys_log_print_hex(status[0]);
+                sys_log_print_msg(")!");
+                sys_log_new_line();
+            #endif /* CONFIG_DRIVERS_DEBUG_ENABLED */
+            }
+        }
+        else
+        {
+        #if defined(CONFIG_DRIVERS_DEBUG_ENABLED) && (CONFIG_DRIVERS_DEBUG_ENABLED == 1)
+            sys_log_print_event_from_module(SYS_LOG_ERROR, RO_MODULE_NAME, "Error reading an state packet!");
+            sys_log_new_line();
+        #endif /* CONFIG_DRIVERS_DEBUG_ENABLED */
+        }
+    }
+    else
+    {
+    #if defined(CONFIG_DRIVERS_DEBUG_ENABLED) && (CONFIG_DRIVERS_DEBUG_ENABLED == 1)
+        sys_log_print_event_from_module(SYS_LOG_ERROR, RO_MODULE_NAME, "Error writing the \"get state\" command!");
+        sys_log_new_line();
+    #endif /* CONFIG_DRIVERS_DEBUG_ENABLED */
+    }
+
+    return res;
+}
+
+
+int16_t ro_get_hk_pkg(ro_config_t config, uint8_t *hk)
+{
+    int16_t res = -1;
+
+    ro_cmd_t cmd = {0};
+
+    cmd.id = RO_CMD_GET_HK_PKG;
+
+    if (ro_write_cmd(config, cmd) == 0)
+    {
+        /* A minimum time gap of 10 ms must be forced between consecutive I2C commands */
+        ro_delay_ms(100);  /* 10 ms is not enough when using the UART interface! */
+
+        if (ro_read(config, hk, RO_FRAME_HK_LEN) == 0)
+        {
+            if (hk[0] == RO_FRAME_ID_HK)
+            {
+                res = RO_FRAME_HK_LEN;
+            }
+            else
+            {
+            #if defined(CONFIG_DRIVERS_DEBUG_ENABLED) && (CONFIG_DRIVERS_DEBUG_ENABLED == 1)
+                sys_log_print_event_from_module(SYS_LOG_ERROR, RO_MODULE_NAME, "Error reading a HK packet! Invalid frame ID (");
+                sys_log_print_hex(hk[0]);
+                sys_log_print_msg(")!");
+                sys_log_new_line();
+            #endif /* CONFIG_DRIVERS_DEBUG_ENABLED */
+            }
+        }
+        else
+        {
+        #if defined(CONFIG_DRIVERS_DEBUG_ENABLED) && (CONFIG_DRIVERS_DEBUG_ENABLED == 1)
+            sys_log_print_event_from_module(SYS_LOG_ERROR, RO_MODULE_NAME, "Error reading a HK packet!");
+            sys_log_new_line();
+        #endif /* CONFIG_DRIVERS_DEBUG_ENABLED */
+        }
+    }
+    else
+    {
+    #if defined(CONFIG_DRIVERS_DEBUG_ENABLED) && (CONFIG_DRIVERS_DEBUG_ENABLED == 1)
+        sys_log_print_event_from_module(SYS_LOG_ERROR, RO_MODULE_NAME, "Error writing the \"get HK\" command!");
+        sys_log_new_line();
+    #endif /* CONFIG_DRIVERS_DEBUG_ENABLED */
+    }
+
+    return res;
+}
+
+int16_t ro_get_event_pkg(ro_config_t config, uint8_t *event)
+{
+    int16_t res = -1;
+
+    ro_cmd_t cmd = {0};
+
+    cmd.id = RO_CMD_GET_EVENT;
+
+    if (ro_write_cmd(config, cmd) == 0)
+    {
+        /* A minimum time gap of 10 ms must be forced between consecutive I2C commands */
+        ro_delay_ms(100);  /* 10 ms is not enough when using the UART interface! */
+
+        if (ro_read(config, event, RO_FRAME_EVENT_LEN) == 0)
+        {
+            if (event[0] == RO_FRAME_ID_EVENT)
+            {
+                res = RO_FRAME_EVENT_LEN;
+            }
+            else
+            {
+            #if defined(CONFIG_DRIVERS_DEBUG_ENABLED) && (CONFIG_DRIVERS_DEBUG_ENABLED == 1)
+                sys_log_print_event_from_module(SYS_LOG_ERROR, RO_MODULE_NAME, "Error reading an event packet! Invalid frame ID (");
+                sys_log_print_hex(event[0]);
+                sys_log_print_msg(")!");
+                sys_log_new_line();
+            #endif /* CONFIG_DRIVERS_DEBUG_ENABLED */
+            }
+        }
+        else
+        {
+        #if defined(CONFIG_DRIVERS_DEBUG_ENABLED) && (CONFIG_DRIVERS_DEBUG_ENABLED == 1)
+            sys_log_print_event_from_module(SYS_LOG_ERROR, RO_MODULE_NAME, "Error reading an event packet!");
+            sys_log_new_line();
+        #endif /* CONFIG_DRIVERS_DEBUG_ENABLED */
+        }
+    }
+    else
+    {
+    #if defined(CONFIG_DRIVERS_DEBUG_ENABLED) && (CONFIG_DRIVERS_DEBUG_ENABLED == 1)
+        sys_log_print_event_from_module(SYS_LOG_ERROR, RO_MODULE_NAME, "Error writing the \"get event\" command!");
+        sys_log_new_line();
+    #endif /* CONFIG_DRIVERS_DEBUG_ENABLED */
+    }
+
+    return res;
+}
 
 int16_t ro_get_navigation_pkg(ro_config_t config, uint8_t *navigation);
 
@@ -333,10 +483,75 @@ int16_t ro_get_iq_pkg(ro_config_t config, uint8_t *iq);
 /*============================================================================*/
 
 int ro_get_state(ro_config_t config,
-                 ro_state_t *state);
+                 ro_state_t *state)
+{
+    int err = -1;
+
+    uint8_t status[RO_FRAME_STATE_LEN] = {0};
+
+    /* Get state bytes */
+    if (ro_get_state_pkg(config, status) == RO_FRAME_STATE_LEN)
+    {
+        /* Check packet ID */
+        if (status[0] == RO_FRAME_ID_STATE)
+        {
+            if(status[0] == RO_FRAME_ID_STATE)
+            {
+                state->current_time =   (uint32_t)status[1] |
+                                        ((uint32_t)status[2] << 8) | 
+                                        ((uint32_t)status[3] << 16) | 
+                                        ((uint32_t)status[4] << 24);
+                state->operational_state = status[5];
+                state->tracking_state = status[6];
+                state->event_available = status[7];
+                state->reserved = status[8];
+
+                err = 0;
+            }
+        }
+    }
+
+    return err;
+}
 
 int ro_get_hk(ro_config_t config,
-              ro_hk_t *hk);
+              ro_hk_t *hk)
+{
+    int err = -1;
+
+    uint8_t hk_raw[RO_FRAME_HK_LEN] = {0};
+
+    /* Get hk bytes */
+    if (ro_get_hk_pkg(config, hk_raw) == RO_FRAME_HK_LEN)
+    {
+        /* Check packet ID */
+        if (hk_raw[0] == RO_FRAME_ID_HK)
+        {
+            /* Verify checksum */
+            if (hk_raw[RO_FRAME_HK_LEN-1] == ro_calc_checksum(hk_raw, RO_FRAME_HK_LEN-1))
+            {
+                hk_data->current_time       = ((uint32_t)hk_raw[4] << 24) |
+                                              ((uint32_t)hk_raw[3] << 16) |
+                                              ((uint32_t)hk_raw[2] << 8)  |
+                                              ((uint32_t)hk_raw[1] << 0);
+                hk_data->elapsed_time       = ((uint32_t)hk_raw[8] << 24) |
+                                              ((uint32_t)hk_raw[7] << 16) |
+                                              ((uint32_t)hk_raw[6] << 8)  |
+                                              ((uint32_t)hk_raw[5] << 0);
+                hk_data->fpga_temperature   = ((uint16_t)hk_raw[9] << 0) | ((uint16_t)hk_raw[10] << 8);
+                hk_data->rf_temperature     = ((uint16_t)hk_raw[11] << 0) | ((uint16_t)hk_raw[12] << 8);
+                hk_data->voltage            = ((uint16_t)hk_raw[13] << 0) | ((uint16_t)hk_raw[14] << 8);
+                hk_data->current            = ((uint16_t)hk_raw[15] << 0) | ((uint16_t)hk_raw[16] << 8);
+                hk_data->operational_state  = hk_raw[17];
+                hk_data->reserved           = hk_raw[18];
+                
+                err = 0;
+            }
+        }
+    }
+
+    return err;
+}
 
 int ro_get_event(ro_config_t config,
                  ro_event_t *event);
@@ -346,50 +561,3 @@ int ro_get_navigation(ro_config_t config,
 
 int ro_get_observation(ro_config_t config,
                        ro_observation_t *observation);
-
-
-/*============================================================================*/
-/* I2C Driver                                                                 */
-/*============================================================================*/
-
-int ro_i2c_init(ro_config_t config);
-
-int ro_i2c_write(ro_config_t config,
-                 uint8_t *data,
-                 uint16_t len);
-
-int ro_i2c_read(ro_config_t config,
-                uint8_t *data,
-                uint16_t len);
-
-/*============================================================================*/
-/* GPIO Driver                                                                */
-/*============================================================================*/
-
-int ro_gpio_init(ro_config_t config);
-
-int ro_gpio_set(ro_config_t config);
-
-int ro_gpio_clear(ro_config_t config);
-
-/*============================================================================*/
-/* UART Driver                                                                */
-/*============================================================================*/
-
-int ro_uart_init(ro_config_t config);
-
-int ro_uart_write(ro_config_t config,
-                  uint8_t *data,
-                  uint16_t len);
-
-int ro_uart_read(ro_config_t config,
-                 uint8_t *data,
-                 uint16_t len);
-
-int ro_uart_rx_available(ro_config_t config);
-
-/*============================================================================*/
-/* Delay                                                                      */
-/*============================================================================*/
-
-void ro_delay_ms(uint32_t ms);

--- a/firmware/drivers/ro/ro.h
+++ b/firmware/drivers/ro/ro.h
@@ -50,6 +50,7 @@
 #define RO_MODULE_NAME          "RO"
 
 #define RO_SLAVE_ADDRESS        0x15
+#define RO_UART_BAUDRATE         115200U
 
 /*============================================================================*/
 /* Command IDs                                                                */
@@ -68,11 +69,12 @@
 
 /* Telemetry */
 #define RO_CMD_GET_STATE            0x30U   /**< Get current instrument state. */
-#define RO_CMD_GET_HK              0x31U   /**< Get housekeeping frame. */
-#define RO_CMD_GET_EVENT           0x32U   /**< Get current occultation event metadata. */
-#define RO_CMD_GET_NAVIGATION      0x33U   /**< Get navigation solution. */
-#define RO_CMD_GET_OBSERVABLES     0x34U   /**< Get scientific observables. */
-#define RO_CMD_GET_IQ              0x35U   /**< Get raw I/Q samples. */
+#define RO_CMD_GET_HK               0x31U   /**< Get housekeeping frame. */
+#define RO_CMD_GET_EVENT            0x32U   /**< Get current occultation event metadata. */
+#define RO_CMD_GET_NAVIGATION       0x33U   /**< Get navigation solution. */
+#define RO_CMD_GET_OBSERVABLES      0x34U   /**< Get scientific observables. */
+#define RO_CMD_GET_IQ               0x35U   /**< Get raw I/Q samples. */
+#define RO_CMD_GET_HK_PKG          0x36U   /**< Updates HK Frame information, and transmit it through the RS-485 interface. */
 
 /*============================================================================*/
 /* Frame IDs                                                                  */
@@ -148,6 +150,7 @@ typedef struct
 typedef struct
 {
     uint32_t current_time;
+    uint32_t elapsed_time;
     uint16_t fpga_temperature;
     uint16_t rf_temperature;
     uint16_t voltage;

--- a/firmware/drivers/ro/ro_delay.c
+++ b/firmware/drivers/ro/ro_delay.c
@@ -1,0 +1,47 @@
+/*
+ * ro_delay.c
+ * 
+ * Copyright (C) 2021, SpaceLab.
+ * 
+ * This file is part of OBDH 2.0.
+ * 
+ * OBDH 2.0 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * OBDH 2.0 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with OBDH 2.0. If not, see <http:/\/www.gnu.org/licenses/>.
+ * 
+ */
+
+/**
+ * \brief RO driver delay implementation.
+ * 
+ * \author Gabriel Mariano Marcelino <gabriel.mm8@gmail.com>
+ * \modified by Renato Augusto Schenkel Meneghin Marchiori
+ * \version 0.0.1
+ * 
+ * \date 2026/08/03
+ * 
+ * \defgroup ro_delay Delay
+ * \ingroup ro
+ * \{
+ */
+
+#include <FreeRTOS.h>
+#include <task.h>
+
+#include "ro.h"
+
+void ro_delay_ms(uint32_t ms) 
+{ 
+    vTaskDelay(pdMS_TO_TICKS(ms)); 
+}
+
+ /** \} End of ro group */

--- a/firmware/drivers/ro/ro_gpio.c
+++ b/firmware/drivers/ro/ro_gpio.c
@@ -1,0 +1,58 @@
+/*
+ * ro_gpio.c
+ * 
+ * Copyright (C) 2021, SpaceLab.
+ * 
+ * This file is part of OBDH 2.0.
+ * 
+ * OBDH 2.0 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * OBDH 2.0 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with OBDH 2.0. If not, see <http:/\/www.gnu.org/licenses/>.
+ * 
+ */
+
+/**
+ * \brief RO GPIO routines implementation.
+ * 
+ * \author Gabriel Mariano Marcelino <gabriel.mm8@gmail.com>
+ * \modified by Renato Augusto Schenkel Meneghin Marchiori
+ * \version 0.7.38
+ * 
+ * \date 2026/08/03
+ * 
+ * \defgroup ro_gpio GPIO
+ * \ingroup ro
+ * \{
+ */
+
+#include <config/config.h>
+#include <system/sys_log/sys_log.h>
+
+#include "ro.h"
+
+int ro_gpio_init(ro_config_t config)
+{
+    gpio_config_t gpio_conf = {0};
+    gpio_conf.mode = GPIO_MODE_OUTPUT;
+    return gpio_init(config.en_pin, gpio_conf);
+}
+
+int ro_gpio_set(ro_config_t config) 
+{ 
+    return gpio_set_state(config.en_pin, true); 
+}
+
+int ro_gpio_clear(ro_config_t config) 
+{ 
+    return gpio_set_state(config.en_pin, false); 
+}
+/** \} End of ro group */

--- a/firmware/drivers/ro/ro_i2c.c
+++ b/firmware/drivers/ro/ro_i2c.c
@@ -1,0 +1,60 @@
+/*
+ * ro_i2c.c
+ * 
+ * Copyright (C) 2021, SpaceLab.
+ * 
+ * This file is part of OBDH 2.0.
+ * 
+ * OBDH 2.0 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * OBDH 2.0 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with OBDH 2.0. If not, see <http:/\/www.gnu.org/licenses/>.
+ * 
+ */
+
+/**
+ * \brief RO I2C routines implementation.
+ * 
+ * \author Gabriel Mariano Marcelino <gabriel.mm8@gmail.com>
+ * \modified by Renato Augusto Schenkel Meneghin Marchiori
+ * \version 0.0.1
+ * 
+ * \date 2026/08/03
+ * 
+ * \defgroup ro_i2c I2C 
+ * \ingroup ro
+ * \{
+ */
+
+#include <drivers/i2c/i2c.h>
+
+#include "ro.h"
+
+int ro_i2c_init(ro_config_t config)
+{
+    i2c_config_t i2c_conf = {0};
+
+    i2c_conf.speed_hz = config.i2c_bitrate;
+
+    return i2c_init(config.i2c_port, i2c_conf);
+}
+
+int ro_i2c_write(ro_config_t config, uint8_t *data, uint16_t len)
+{
+    return i2c_write(config.i2c_port, RO_SLAVE_ADDRESS, data, len);
+}
+
+int ro_i2c_read(ro_config_t config, uint8_t *data, uint16_t len)
+{
+    return i2c_read(config.i2c_port, RO_SLAVE_ADDRESS, data, len);
+}
+
+/** \} End of ro group */

--- a/firmware/drivers/ro/ro_uart.c
+++ b/firmware/drivers/ro/ro_uart.c
@@ -1,0 +1,74 @@
+/*
+ * ro_uart.c
+ * 
+ * Copyright (C) 2021, SpaceLab.
+ * 
+ * This file is part of OBDH 2.0.
+ * 
+ * OBDH 2.0 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * OBDH 2.0 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with OBDH 2.0. If not, see <http:/\/www.gnu.org/licenses/>.
+ * 
+ */
+
+/**
+ * \brief RO UART routines implementation.
+ * 
+ * \author Gabriel Mariano Marcelino <gabriel.mm8@gmail.com>
+ * \modified by Renato Augusto Schenkel Meneghin Marchiori
+ * \version 0.0.1
+ * 
+ * \date 2026/08/03
+ * 
+ * \defgroup ro_uart UART 
+ * \ingroup ro
+ * \{
+ */
+#include <drivers/uart/uart.h>  
+
+#include "ro.h"
+
+int ro_uart_init(ro_config_t config)
+{
+    uart_config_t uart_conf = {0};
+    int err = -1;
+    
+    uart_conf.baudrate = RO_UART_BAUDRATE;
+    uart_conf.data_bits = 8U;
+    uart_conf.parity = UART_NO_PARITY;
+    uart_conf.stop_bits = UART_ONE_STOP_BIT;
+
+    if (uart_init(config.uart_port, uart_conf) == 0) 
+    {
+        err = uart_rx_enable(config.uart_port);
+    }
+    
+    return err;
+}
+
+int ro_uart_write(ro_config_t config, uint8_t *data, uint16_t len) 
+{ 
+    int dummy = uart_flush(config.uart_port); 
+    
+    return uart_write(config.uart_port, data, len); 
+}
+
+int ro_uart_read(ro_config_t config, uint8_t *data, uint16_t len) 
+{ 
+    return uart_read(config.uart_port, data, len); 
+}
+
+int ro_uart_rx_available(ro_config_t config) 
+{ 
+    return (int)uart_read_available(config.uart_port); 
+}
+/** \} End of ro group */

--- a/firmware/tests/drivers/Makefile
+++ b/firmware/tests/drivers/Makefile
@@ -6,6 +6,7 @@ TARGET_ISIS_ANTENNA=isis_antenna_unit_test
 TARGET_SL_EPS2=sl_eps2_unit_test
 TARGET_MT25Q=mt25q_unit_test
 TARGET_SL_TTC2=sl_ttc2_unit_test
+TARGET_RO=ro_unit_test
 
 ifndef BUILD_DIR
 	BUILD_DIR=$(CURDIR)
@@ -29,10 +30,11 @@ SL_EPS2_TEST_FLAGS=$(FLAGS),--wrap=tca4311a_init,--wrap=tca4311a_enable,--wrap=t
 MT25Q_TEST_FLAGS=$(FLAGS),--wrap=spi_init,--wrap=spi_select_slave,--wrap=spi_write,--wrap=spi_read,--wrap=spi_transfer,--wrap=gpio_init,--wrap=gpio_set_state,--wrap=gpio_get_state,--wrap=gpio_toggle,--wrap=spi_mutex_take,--wrap=spi_mutex_give
 
 SL_TTC2_TEST_FLAGS=$(FLAGS),--wrap=spi_init,--wrap=spi_select_slave,--wrap=spi_write,--wrap=spi_read,--wrap=spi_transfer,--wrap=gpio_init,--wrap=gpio_set_state,--wrap=gpio_get_state,--wrap=gpio_toggle,--wrap=spi_mutex_take,--wrap=spi_mutex_give,--wrap=sl_ttc2_spi_read,--wrap=crc8_get_val
+RO_TEST_FLAGS=$(FLAGS),--wrap=i2c_init,--wrap=i2c_write,--wrap=i2c_read,--wrap=uart_init,--wrap=uart_write,--wrap=uart_read,--wrap=uart_rx_enable,--wrap=uart_read_available,--wrap=uart_flush,--wrap=gpio_init,--wrap=gpio_set_state
 
 .PHONY: all
 .PHONY: all
-all: cy15x102qn_test tps382x_test tca4311a_test edc_test isis_antenna_test sl_eps2_test mt25q_test sl_ttc2_test
+all: cy15x102qn_test tps382x_test tca4311a_test edc_test isis_antenna_test sl_eps2_test mt25q_test sl_ttc2_test ro_test
 
 .PHONY: cy15x102qn_test
 cy15x102qn_test: $(BUILD_DIR)/cy15x102qn.o $(BUILD_DIR)/cy15x102qn_mutex.o $(BUILD_DIR)/cy15x102qn_gpio.o $(BUILD_DIR)/cy15x102qn_spi.o $(BUILD_DIR)/cy15x102qn_test.o $(BUILD_DIR)/sys_log_wrap.o $(BUILD_DIR)/spi_wrap.o $(BUILD_DIR)/gpio_wrap.o $(BUILD_DIR)/semphr.o
@@ -65,6 +67,10 @@ mt25q_test: $(BUILD_DIR)/mt25q.o $(BUILD_DIR)/mt25q_mutex.o $(BUILD_DIR)/mt25q_d
 .PHONY: sl_ttc2_test
 sl_ttc2_test: $(BUILD_DIR)/sl_ttc2.o $(BUILD_DIR)/sl_ttc2_spi.o $(BUILD_DIR)/sl_ttc2_delay.o $(BUILD_DIR)/sl_ttc2_test.o $(BUILD_DIR)/sys_log_wrap.o $(BUILD_DIR)/spi_wrap.o $(BUILD_DIR)/gpio_wrap.o $(BUILD_DIR)/task.o $(BUILD_DIR)/sl_ttc2_mutex.o $(BUILD_DIR)/sl_ttc2_wrap.o $(BUILD_DIR)/semphr.o
 	$(CC) $(SL_TTC2_TEST_FLAGS) $(BUILD_DIR)/sl_ttc2.o $(BUILD_DIR)/sl_ttc2_spi.o $(BUILD_DIR)/sl_ttc2_delay.o $(BUILD_DIR)/sl_ttc2_test.o $(BUILD_DIR)/sys_log_wrap.o $(BUILD_DIR)/spi_wrap.o $(BUILD_DIR)/gpio_wrap.o $(BUILD_DIR)/task.o $(BUILD_DIR)/sl_ttc2_mutex.o $(BUILD_DIR)/sl_ttc2_wrap.o $(BUILD_DIR)/semphr.o -o $(BUILD_DIR)/$(TARGET_SL_TTC2) -lm -lcmocka
+
+.PHONY: ro_test
+ro_test: $(BUILD_DIR)/ro.o $(BUILD_DIR)/ro_i2c.o $(BUILD_DIR)/ro_uart.o $(BUILD_DIR)/ro_gpio.o $(BUILD_DIR)/ro_test.o $(BUILD_DIR)/i2c_wrap.o $(BUILD_DIR)/uart_wrap.o $(BUILD_DIR)/gpio_wrap.o
+	$(CC) $(RO_TEST_FLAGS) $(BUILD_DIR)/ro.o $(BUILD_DIR)/ro_i2c.o $(BUILD_DIR)/ro_uart.o $(BUILD_DIR)/ro_gpio.o $(BUILD_DIR)/ro_test.o $(BUILD_DIR)/i2c_wrap.o $(BUILD_DIR)/uart_wrap.o $(BUILD_DIR)/gpio_wrap.o -o $(BUILD_DIR)/$(TARGET_RO) -lcmocka
 
 # Drivers
 $(BUILD_DIR)/cy15x102qn.o: ../../drivers/cy15x102qn/cy15x102qn.c
@@ -99,6 +105,18 @@ $(BUILD_DIR)/edc_gpio.o: ../../drivers/edc/edc_gpio.c
 
 $(BUILD_DIR)/edc_delay.o: ../../drivers/edc/edc_delay.c
 	$(CC) $(EDC_TEST_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/ro.o: ../../drivers/ro/ro.c
+	$(CC) $(RO_TEST_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/ro_i2c.o: ../../drivers/ro/ro_i2c.c
+	$(CC) $(RO_TEST_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/ro_uart.o: ../../drivers/ro/ro_uart.c
+	$(CC) $(RO_TEST_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/ro_gpio.o: ../../drivers/ro/ro_gpio.c
+	$(CC) $(RO_TEST_FLAGS) -c $< -o $@
 
 $(BUILD_DIR)/isis_antenna.o: ../../drivers/isis_antenna/isis_antenna.c
 	$(CC) $(ISIS_ANTENNA_TEST_FLAGS) -c $< -o $@
@@ -158,6 +176,9 @@ $(BUILD_DIR)/tca4311a_test.o: tca4311a_test.c
 $(BUILD_DIR)/edc_test.o: edc_test.c
 	$(CC) $(EDC_TEST_FLAGS) -c $< -o $@
 
+$(BUILD_DIR)/ro_test.o: ro_test.c
+	$(CC) $(RO_TEST_FLAGS) -c $< -o $@
+
 $(BUILD_DIR)/isis_antenna_test.o: isis_antenna_test.c
 	$(CC) $(ISIS_ANTENNA_TEST_FLAGS) -c $< -o $@
 
@@ -209,4 +230,4 @@ $(BUILD_DIR)/semphr.o: ../freertos_sim/semphr.c
 
 .PHONY: clean
 clean:
-	rm $(BUILD_DIR)/$(TARGET_CY15X102QN) $(BUILD_DIR)/$(TARGET_TPS382X) $(BUILD_DIR)/$(TARGET_TCA4311A) $(BUILD_DIR)/$(TARGET_EDC) $(BUILD_DIR)/$(TARGET_ISIS_ANTENNA) $(BUILD_DIR)/$(TARGET_SL_EPS2) $(BUILD_DIR)/$(TARGET_MT25Q) $(BUILD_DIR)/$(TARGET_SL_TTC2) $(BUILD_DIR)/*.o
+	rm $(BUILD_DIR)/$(TARGET_CY15X102QN) $(BUILD_DIR)/$(TARGET_TPS382X) $(BUILD_DIR)/$(TARGET_TCA4311A) $(BUILD_DIR)/$(TARGET_EDC) $(BUILD_DIR)/$(TARGET_ISIS_ANTENNA) $(BUILD_DIR)/$(TARGET_SL_EPS2) $(BUILD_DIR)/$(TARGET_MT25Q) $(BUILD_DIR)/$(TARGET_SL_TTC2) $(BUILD_DIR)/$(TARGET_RO) $(BUILD_DIR)/*.o

--- a/firmware/tests/drivers/ro_test.c
+++ b/firmware/tests/drivers/ro_test.c
@@ -1,0 +1,38 @@
+/*
+ * ro_test.c
+ * Copyright The OBDH 2.0 Contributors.
+ *
+ * Unit tests of the Radio Occultation payload driver.
+ */
+
+/** \defgroup ro_unit_test RO \ingroup tests \{ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <drivers/ro/ro.h>
+
+void ro_delay_ms(uint32_t ms) { (void)ms; }
+static void test_checksum_and_invalid_command(void **state)
+{
+    uint8_t data[] = { 0x11U, 0x22U, 0x33U };
+    ro_config_t config = {0};
+    (void)state;
+    assert_int_equal(ro_calc_checksum(data, sizeof(data)), 0U);
+    assert_int_equal(ro_write_cmd(config, (ro_cmd_t){ 0x99U, 0U }), -1);
+}
+static void test_state_parser_rejects_null_output(void **state)
+{
+    ro_config_t config = {0};
+    (void)state;
+    assert_int_equal(ro_get_state(config, NULL), -1);
+}
+int main(void)
+{
+    const struct CMUnitTest tests[] = { cmocka_unit_test(test_checksum_and_invalid_command), cmocka_unit_test(test_state_parser_rejects_null_output) };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+/** \} End of ro_unit_test group */

--- a/firmware/tests/mockups/drivers/edc_wrap.h
+++ b/firmware/tests/mockups/drivers/edc_wrap.h
@@ -42,45 +42,25 @@
 #include <drivers/edc/edc.h>
 
 int __wrap_edc_init(edc_config_t config);
-
 int __wrap_edc_enable(edc_config_t config);
-
 int __wrap_edc_disable(edc_config_t config);
-
 int __wrap_edc_write_cmd(edc_config_t config, edc_cmd_t cmd);
-
 int __wrap_edc_read(edc_config_t config, uint8_t *data, uint16_t len);
-
 int __wrap_edc_check_device(edc_config_t config);
-
 int __wrap_edc_set_rtc_time(edc_config_t config, uint32_t time);
-
 int __wrap_edc_pop_ptt_pkg(edc_config_t config);
-
 int __wrap_edc_pause_ptt_task(edc_config_t config);
-
 int __wrap_edc_resume_ptt_task(edc_config_t config);
-
 int __wrap_edc_start_adc_task(edc_config_t config);
-
 int16_t __wrap_edc_get_state_pkg(edc_config_t config, uint8_t *status);
-
 int16_t __wrap_edc_get_ptt_pkg(edc_config_t config, uint8_t *pkg);
-
 int16_t __wrap_edc_get_hk_pkg(edc_config_t config, uint8_t *hk);
-
 int16_t __wrap_edc_get_adc_seq(edc_config_t config, uint8_t *seq);
-
 int __wrap_edc_echo(edc_config_t config);
-
 uint16_t __wrap_edc_calc_checksum(uint8_t *data, uint16_t len);
-
 int __wrap_edc_get_state(edc_config_t config, edc_state_t *state_data);
-
 int __wrap_edc_get_ptt(edc_config_t config, edc_ptt_t *ptt_data);
-
 int __wrap_edc_get_hk(edc_config_t config, edc_hk_t *hk_data);
-
 void __wrap_edc_delay_ms(uint32_t ms);
 
 #endif /* EDC_WRAP_H_ */

--- a/firmware/tests/mockups/drivers/ro_wrap.c
+++ b/firmware/tests/mockups/drivers/ro_wrap.c
@@ -1,0 +1,389 @@
+/*
+ * ro_wrap.c
+ *
+ * Copyright The OBDH 2.0 Contributors.
+ *
+ * This file is part of OBDH 2.0.
+ *
+ * OBDH 2.0 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OBDH 2.0 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OBDH 2.0. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * \brief RO driver wrap implementation.
+ *
+ * \author Gabriel Mariano Marcelino <gabriel.mm8@gmail.com>
+ * \author Renato Augusto Schenkel Meneghin Marchiori
+ *
+ * \version 0.0.1
+ *
+ * \date 2026/06/10
+ *
+ * \addtogroup ro_wrap
+ * \{
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <setjmp.h>
+#include <float.h>
+#include <cmocka.h>
+
+#include "ro_wrap.h"
+
+#define RO_CHECK_CONFIG(config)                       \
+    do                                                 \
+    {                                                  \
+        check_expected(config.interface);              \
+        check_expected(config.en_pin);                 \
+                                                       \
+        if (config.interface == RO_IF_UART)             \
+        {                                              \
+            check_expected(config.uart_port);          \
+        }                                              \
+        else if (config.interface == RO_IF_I2C)        \
+        {                                              \
+            check_expected(config.i2c_port);           \
+            check_expected(config.i2c_bitrate);        \
+        }                                              \
+    } while (false)
+
+#define RO_CHECK_DATA(config, data, len)               \
+    do                                                 \
+    {                                                  \
+        RO_CHECK_CONFIG(config);                       \
+        check_expected_ptr(data);                      \
+        check_expected(len);                           \
+    } while (false)
+
+#define RO_MOCK_PACKAGE(config, data)                  \
+    do                                                 \
+    {                                                  \
+        RO_CHECK_CONFIG(config);                       \
+                                                       \
+        if ((data) != NULL)                            \
+        {                                              \
+            (data) = mock_ptr_type(uint8_t *);         \
+        }                                              \
+    } while (false)
+
+int __wrap_ro_init(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_enable(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_disable(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_check_device(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_echo(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_start_tracking(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_stop_tracking(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_start_capture(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_abort_capture(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_enable_open_loop(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_disable_open_loop(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_clear_event(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_i2c_init(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_gpio_init(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_gpio_set(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_gpio_clear(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_uart_init(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_uart_rx_available(ro_config_t config)
+{
+    RO_CHECK_CONFIG(config);
+    return mock_type(int);
+}
+
+int __wrap_ro_set_rtc_time(ro_config_t config, uint32_t time)
+{
+    RO_CHECK_CONFIG(config);
+    check_expected(time);
+
+    return mock_type(int);
+}
+
+int __wrap_ro_write_cmd(ro_config_t config, ro_cmd_t cmd)
+{
+    RO_CHECK_CONFIG(config);
+    check_expected(cmd.id);
+    check_expected(cmd.param);
+
+    return mock_type(int);
+}
+
+int __wrap_ro_read(ro_config_t config, uint8_t *data, uint16_t len)
+{
+    RO_CHECK_DATA(config, data, len);
+    return mock_type(int);
+}
+
+uint16_t __wrap_ro_calc_checksum(uint8_t *data, uint16_t len)
+{
+    check_expected_ptr(data);
+    check_expected(len);
+
+    return mock_type(uint16_t);
+}
+
+int16_t __wrap_ro_get_state_pkg(ro_config_t config, uint8_t *status)
+{
+    RO_MOCK_PACKAGE(config, status);
+    return mock_type(int16_t);
+}
+
+int16_t __wrap_ro_get_hk_pkg(ro_config_t config, uint8_t *hk)
+{
+    RO_MOCK_PACKAGE(config, hk);
+    return mock_type(int16_t);
+}
+
+int16_t __wrap_ro_get_event_pkg(ro_config_t config, uint8_t *event)
+{
+    RO_MOCK_PACKAGE(config, event);
+    return mock_type(int16_t);
+}
+
+int16_t __wrap_ro_get_navigation_pkg(ro_config_t config, uint8_t *navigation)
+{
+    RO_MOCK_PACKAGE(config, navigation);
+    return mock_type(int16_t);
+}
+
+int16_t __wrap_ro_get_observation_pkg(ro_config_t config, uint8_t *observation)
+{
+    RO_MOCK_PACKAGE(config, observation);
+    return mock_type(int16_t);
+}
+
+int16_t __wrap_ro_get_iq_pkg(ro_config_t config, uint8_t *iq)
+{
+    RO_MOCK_PACKAGE(config, iq);
+    return mock_type(int16_t);
+}
+
+int __wrap_ro_get_state(ro_config_t config, ro_state_t *state)
+{
+    RO_CHECK_CONFIG(config);
+
+    if (state != NULL)
+    {
+        state->current_time = mock_type(uint32_t);
+        state->operational_state = mock_type(uint8_t);
+        state->tracking_state = mock_type(uint8_t);
+        state->event_available = mock_type(uint8_t);
+        state->reserved = mock_type(uint8_t);
+    }
+
+    return mock_type(int);
+}
+
+int __wrap_ro_get_hk(ro_config_t config, ro_hk_t *hk)
+{
+    uint16_t i = 0U;
+
+    RO_CHECK_CONFIG(config);
+
+    if (hk != NULL)
+    {
+        hk->current_time = mock_type(uint32_t);
+        hk->fpga_temperature = mock_type(uint16_t);
+        hk->rf_temperature = mock_type(uint16_t);
+        hk->voltage = mock_type(uint16_t);
+        hk->current = mock_type(uint16_t);
+        hk->operational_state = mock_type(uint8_t);
+
+        for (i = 0U; i < sizeof(hk->reserved); i++)
+        {
+            hk->reserved[i] = mock_type(uint8_t);
+        }
+    }
+
+    return mock_type(int);
+}
+
+int __wrap_ro_get_event(ro_config_t config, ro_event_t *event)
+{
+    RO_CHECK_CONFIG(config);
+
+    if (event != NULL)
+    {
+        event->event_id = mock_type(uint32_t);
+        event->timestamp_start = mock_type(uint32_t);
+        event->timestamp_end = mock_type(uint32_t);
+        event->prn = mock_type(uint8_t);
+        event->duration_ms = mock_type(uint32_t);
+        event->num_samples = mock_type(uint32_t);
+        event->event_status = mock_type(uint8_t);
+    }
+
+    return mock_type(int);
+}
+
+int __wrap_ro_get_navigation(ro_config_t config, ro_navigation_t *navigation)
+{
+    RO_CHECK_CONFIG(config);
+
+    if (navigation != NULL)
+    {
+        navigation->sat_pos_x = mock_type(int32_t);
+        navigation->sat_pos_y = mock_type(int32_t);
+        navigation->sat_pos_z = mock_type(int32_t);
+        navigation->sat_vel_x = mock_type(int32_t);
+        navigation->sat_vel_y = mock_type(int32_t);
+        navigation->sat_vel_z = mock_type(int32_t);
+        navigation->gnss_time = mock_type(uint32_t);
+    }
+
+    return mock_type(int);
+}
+
+int __wrap_ro_get_observation(ro_config_t config, ro_observation_t *observation)
+{
+    uint16_t i = 0U;
+
+    RO_CHECK_CONFIG(config);
+
+    if (observation != NULL)
+    {
+        observation->observation_id = mock_type(uint32_t);
+        observation->gnss_time = mock_type(uint32_t);
+        observation->prn = mock_type(uint8_t);
+        observation->carrier_phase = mock_type(int32_t);
+        observation->code_phase = mock_type(int32_t);
+        observation->doppler = mock_type(int32_t);
+        observation->snr = mock_type(uint16_t);
+        observation->tracking_state = mock_type(uint8_t);
+
+        for (i = 0U; i < sizeof(observation->reserved); i++)
+        {
+            observation->reserved[i] = mock_type(uint8_t);
+        }
+    }
+
+    return mock_type(int);
+}
+
+int __wrap_ro_i2c_write(ro_config_t config, uint8_t *data, uint16_t len)
+{
+    RO_CHECK_DATA(config, data, len);
+    return mock_type(int);
+}
+
+int __wrap_ro_i2c_read(ro_config_t config, uint8_t *data, uint16_t len)
+{
+    RO_CHECK_DATA(config, data, len);
+    return mock_type(int);
+}
+
+int __wrap_ro_uart_write(ro_config_t config, uint8_t *data, uint16_t len)
+{
+    RO_CHECK_DATA(config, data, len);
+    return mock_type(int);
+}
+
+int __wrap_ro_uart_read(ro_config_t config, uint8_t *data, uint16_t len)
+{
+    RO_CHECK_DATA(config, data, len);
+    return mock_type(int);
+}
+
+void __wrap_ro_delay_ms(uint32_t ms)
+{
+    check_expected(ms);
+}
+
+/** \} End of ro_wrap group */

--- a/firmware/tests/mockups/drivers/ro_wrap.h
+++ b/firmware/tests/mockups/drivers/ro_wrap.h
@@ -1,0 +1,81 @@
+/*
+ * ro_wrap.h
+ *
+ * Copyright The OBDH 2.0 Contributors.
+ *
+ * This file is part of OBDH 2.0.
+ *
+ * OBDH 2.0 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OBDH 2.0 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OBDH 2.0. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * \brief RO driver wrap definition.
+ *
+ * \author Gabriel Mariano Marcelino <gabriel.mm8@gmail.com>
+ * \author Renato Augusto Schenkel Meneghin Marchiori
+ *
+ * \version 0.0.1
+ *
+ * \date 2026/06/10
+ *
+ * \defgroup ro_wrap RO Wrap
+ * \ingroup tests
+ * \{
+ */
+
+#ifndef RO_WRAP_H_
+#define RO_WRAP_H_
+
+#include <stdint.h>
+
+#include <drivers/ro/ro.h>
+
+int __wrap_ro_init(ro_config_t config);
+int __wrap_ro_enable(ro_config_t config);
+int __wrap_ro_disable(ro_config_t config);
+int __wrap_ro_check_device(ro_config_t config);
+int __wrap_ro_set_rtc_time(ro_config_t config, uint32_t time);
+
+int __wrap_ro_write_cmd(ro_config_t config, ro_cmd_t cmd);
+int __wrap_ro_read(ro_config_t config, uint8_t *data, uint16_t len);
+int __wrap_ro_echo(ro_config_t config);
+uint16_t __wrap_ro_calc_checksum(uint8_t *data, uint16_t len);
+
+int __wrap_ro_start_tracking(ro_config_t config);
+int __wrap_ro_stop_tracking(ro_config_t config);
+int __wrap_ro_start_capture(ro_config_t config);
+int __wrap_ro_abort_capture(ro_config_t config);
+int __wrap_ro_enable_open_loop(ro_config_t config);
+int __wrap_ro_disable_open_loop(ro_config_t config);
+int __wrap_ro_clear_event(ro_config_t config);
+
+int16_t __wrap_ro_get_state_pkg(ro_config_t config, uint8_t *status);
+int16_t __wrap_ro_get_hk_pkg(ro_config_t config, uint8_t *hk);
+int16_t __wrap_ro_get_event_pkg(ro_config_t config, uint8_t *event);
+int16_t __wrap_ro_get_navigation_pkg(ro_config_t config, uint8_t *navigation);
+int16_t __wrap_ro_get_observation_pkg(ro_config_t config, uint8_t *observation);
+int16_t __wrap_ro_get_iq_pkg(ro_config_t config, uint8_t *iq);
+
+int __wrap_ro_get_state(ro_config_t config, ro_state_t *state);
+int __wrap_ro_get_hk(ro_config_t config, ro_hk_t *hk);
+int __wrap_ro_get_event(ro_config_t config, ro_event_t *event);
+int __wrap_ro_get_navigation(ro_config_t config, ro_navigation_t *navigation);
+int __wrap_ro_get_observation(ro_config_t config, ro_observation_t *observation);
+
+void __wrap_ro_delay_ms(uint32_t ms);
+
+#endif /* RO_WRAP_H_ */
+
+/** \} End of ro_wrap group */


### PR DESCRIPTION
- Introduced the RO driver for handling Radio Occultation payloads, including UART and I2C communication.
- Implemented core functionalities such as command writing, state retrieval, housekeeping data fetching, and event handling.
- Created a mock wrapper for unit testing the RO driver functions.
- Updated Makefile to include RO driver compilation and testing.
- Added README documentation for the RO driver.